### PR TITLE
battery: use external temperature sensor based on ADC_VERSION

### DIFF
--- a/Src/dronecan_application/modules/battery/battery.cpp
+++ b/Src/dronecan_application/modules/battery/battery.cpp
@@ -75,12 +75,10 @@ void VtolBattery::_update_voltage_and_current() {
 }
 
 void VtolBattery::_update_temperature() {
-    uint16_t adc_temperature = AdcPeriphery::get(AdcChannel::ADC_TEMPERATURE);
-    static const uint16_t TEMP_REF = 25;
-    static const uint16_t ADC_REF = 1750;   ///< v_ref / 3.3 * 4095
-    static const uint16_t AVG_SLOPE = 5;    ///< avg_slope/(3.3/4096)
-    float kelvin = (ADC_REF - adc_temperature) / AVG_SLOPE + TEMP_REF + 273.15;
-    _battery_info.temperature = kelvin;
+    // B57861-S 103-F40, 10 kilohm, 1%, NTCthermistor
+    float raw = AdcPeriphery::get(AdcChannel::ADC_VERSION);
+    float celcius = 0.00000267f*raw*raw + 0.02734039f*raw + 5.48039378f;
+    _battery_info.temperature = celcius + 273.15f;
 }
 
 void VtolBattery::_update_soc() {


### PR DESCRIPTION
Temperature sensor test.
Initially, it had the environment temperature. Then it was heated with soldering iron to 100 °C.

![image](https://github.com/Innopolis-UAV-Team/vtol_pmu_node/assets/36133264/9762b194-dcdc-4e99-a6ca-91871c0870a1)

P.S. On the plot we see Celsius, but after the test it was actually converted to Kelvin as it should be.